### PR TITLE
Range graph

### DIFF
--- a/app/jobs/aggregate_samples_job.rb
+++ b/app/jobs/aggregate_samples_job.rb
@@ -1,4 +1,5 @@
 class AggregateSamplesJob < ApplicationJob
+  BUCKET = 20.minutes
 
   def perform
     Measurement.find_each do |measurement|
@@ -6,8 +7,8 @@ class AggregateSamplesJob < ApplicationJob
         aggregated_samples = measurement
           .samples
           .where(timestamp: aggregation_window)
-          .select("group_concat(id) as ids, strftime('%Y-%m-%d %H:%M', samples.timestamp) AS timestamp, MIN(value) as min, MEDIAN(value) as value, MAX(value) as max")
-          .group("strftime('%Y-%m-%d %H:%M', samples.timestamp)")
+          .select("group_concat(id) as ids, datetime((strftime('%s', samples.timestamp) / #{BUCKET.to_i}) * #{BUCKET.to_i}, 'unixepoch') AS timestamp, MIN(value) as min, MEDIAN(value) as value, MAX(value) as max")
+          .group("strftime('%s', samples.timestamp) / #{BUCKET.to_i}")
           .having("COUNT(id) > 1")
 
         measurement.samples.where(id: aggregated_samples.flat_map { _1.ids.split(",").map(&:to_i) }).delete_all
@@ -21,6 +22,10 @@ class AggregateSamplesJob < ApplicationJob
     def aggregation_window
       # Window during which we aggregate samples, delayed samples that
       # come in after this window will not be aggregated.
-      24.hours.ago...1.hour.ago
+      24.hours.ago...current_bucket_start
+    end
+
+    def current_bucket_start
+      Time.zone.at(Time.current.to_i / BUCKET.to_i * BUCKET.to_i)
     end
 end

--- a/app/views/measurements/_line_graph.html.erb
+++ b/app/views/measurements/_line_graph.html.erb
@@ -21,6 +21,20 @@ end
 path_data = coordinates.map.with_index do |coordinates, index|
   "#{index.zero? ? 'M' : 'L'} #{coordinates.first},#{coordinates.second}"
 end.join(" ")
+
+# Band between the min and max of each sample; non-aggregated samples
+# fall back to their value so the band runs through.
+band_points = coordinates.map do |x, _y, sample|
+  max_y = height - normalize((sample.max || sample.value).to_f, min_value, max_value) * height
+  min_y = height - normalize((sample.min || sample.value).to_f, min_value, max_value) * height
+  [x, max_y, min_y]
+end
+
+band_data = band_points.map.with_index do |(x, max_y, _), index|
+  "#{index.zero? ? 'M' : 'L'} #{x},#{max_y}"
+end.join(" ")
+band_data << band_points.reverse.map { |x, _, min_y| " L #{x},#{min_y}" }.join
+band_data << " Z"
 %>
 
 <div class="relative">
@@ -38,13 +52,16 @@ end.join(" ")
       </div>
     <% end %>
   </div>
-  
+
   <div class="rounded-md contain-paint py-1.5">
     <div
       style="--grid-color: color-mix(in oklab, var(--color-zinc-400) 7%, transparent)"
       class="absolute inset-0 h-full w-full bg-zinc-800 bg-[linear-gradient(to_right,var(--grid-color)_1px,transparent_1px),linear-gradient(to_bottom,var(--grid-color)_1px,transparent_1px)] bg-size-[10px_10px] bg-center"
     ></div>
     <svg width="<%= width %>" height="<%= height %>" class="isolate text-white">
+      <path d="<%= band_data %>"
+            fill="currentColor"
+            fill-opacity="0.15" />
       <path d="<%= path_data %>"
             stroke="currentColor"
             stroke-width="1px"

--- a/app/views/measurements/_line_graph.html.erb
+++ b/app/views/measurements/_line_graph.html.erb
@@ -3,7 +3,7 @@ width = 150
 height = 50
 
 min_time, max_time = samples.map(&:timestamp).minmax
-min_value, max_value = 0, samples.map(&:value).max
+min_value, max_value = 0, samples.map { it.max || it.value }.max
 
 def normalize(value, min, max)
   return 0 if max == min

--- a/test/jobs/aggregate_samples_job_test.rb
+++ b/test/jobs/aggregate_samples_job_test.rb
@@ -1,44 +1,67 @@
 require "test_helper"
 
 class AggregateSamplesJobTest < ActiveJob::TestCase
-  test "aggregates older samples only" do
-    travel_to Time.current do
-      measurement = measurements(:puma_backlog)
+  setup do
+    @bucket = AggregateSamplesJob::BUCKET
+    travel_to Time.current.beginning_of_hour + @bucket / 2
+  end
 
-      measurement.samples.create!(timestamp: 61.minutes.ago)
-      measurement.samples.create!(timestamp: 61.minutes.ago, value: 1)
-      measurement.samples.create!(timestamp: 60.minutes.ago)
-      measurement.samples.create!(timestamp: 59.minutes.ago)
+  test "aggregates completed buckets only" do
+    measurement = measurements(:puma_backlog)
 
-      perform_enqueued_jobs do
-        assert_difference("Sample.count", -1) do
-          AggregateSamplesJob.perform_later
-        end
+    # To be aggregated
+    measurement.samples.create!(timestamp: (@bucket + 5.minutes).ago)
+    measurement.samples.create!(timestamp: (@bucket + 4.minutes).ago, value: 1)
+
+    # Within the latest window
+    measurement.samples.create!(timestamp: 5.minutes.ago)
+    measurement.samples.create!(timestamp: 4.minutes.ago)
+
+    perform_enqueued_jobs do
+      assert_difference("Sample.count", -1) do
+        AggregateSamplesJob.perform_later
       end
-
-      assert_equal 61.minutes.ago.beginning_of_minute, measurement.samples.first.timestamp
-      assert_equal 1, measurement.samples.first.max
     end
+
+    aggregated = measurement.samples.first
+    assert_equal 30.minutes.ago, aggregated.timestamp
+    assert_equal 1, aggregated.max
+
+    # The open bucket keeps its raw samples.
+    assert_equal 2, measurement.samples.where(min: nil).count
   end
 
   test "correctly aggregates the min, median, and max values" do
-    travel_to Time.current do
-      measurement = measurements(:puma_backlog)
+    measurement = measurements(:puma_backlog)
 
-      measurement.samples.create!(timestamp: 61.minutes.ago, value: 4)
-      measurement.samples.create!(timestamp: 61.minutes.ago, value: 3)
-      measurement.samples.create!(timestamp: 61.minutes.ago, value: 1)
+    measurement.samples.create!(timestamp: (@bucket + 5.minutes).ago, value: 4)
+    measurement.samples.create!(timestamp: (@bucket + 4.minutes).ago, value: 3)
+    measurement.samples.create!(timestamp: (@bucket + 3.minutes).ago, value: 1)
 
-      perform_enqueued_jobs do
-        assert_difference("Sample.count", -2) do
-          AggregateSamplesJob.perform_later
-        end
+    perform_enqueued_jobs do
+      assert_difference("Sample.count", -2) do
+        AggregateSamplesJob.perform_later
       end
-
-      assert_equal 61.minutes.ago.beginning_of_minute, measurement.samples.first.timestamp
-      assert_equal 1, measurement.samples.first.min
-      assert_equal 3, measurement.samples.first.value
-      assert_equal 4, measurement.samples.first.max
     end
+
+    aggregated = measurement.samples.first
+    assert_equal 30.minutes.ago, aggregated.timestamp
+    assert_equal 1, aggregated.min
+    assert_equal 3, aggregated.value
+    assert_equal 4, aggregated.max
+  end
+
+  test "does not aggregate buckets with a single sample" do
+    measurement = measurements(:puma_backlog)
+
+    measurement.samples.create!(timestamp: (@bucket + 5.minutes).ago, value: 4)
+
+    perform_enqueued_jobs do
+      assert_no_difference("Sample.count") do
+        AggregateSamplesJob.perform_later
+      end
+    end
+
+    assert_nil measurement.samples.first.min
   end
 end


### PR DESCRIPTION
We already store samples with aggregated min/max values. This PR introduces a band graph to visualize this data.  To make this readable in our small graph size we increase the bucket size to 20 minutes and aggregate up to the last bucket (instead of a hard cut off at 1 hour).

<img width="478" height="274" alt="CleanShot 2026-07-09 at 11 33 13@2x" src="https://github.com/user-attachments/assets/1546f813-240d-44ba-8955-f42fba24823e" />
